### PR TITLE
removes postgresql from text matrix in the GHA workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,6 @@ jobs:
     runs-on: ubuntu-latest
 
     services:
-      postgres:
-        image: postgres:13
-        env:
-          POSTGRES_USER: "postgres"
-          POSTGRES_HOST_AUTH_METHOD: "trust"
-        ports:
-          - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
-
       mariadb:
         image: mariadb:10
         env:
@@ -36,7 +27,7 @@ jobs:
       matrix:
         php: ["8.2", "8.3"]
         moodle-branch: ["MOODLE_405_STABLE"]
-        database: [pgsql, mariadb]
+        database: [mariadb]
 
     steps:
       - name: Check out repository code


### PR DESCRIPTION
refs #18 

the plugin's SQL queries are not cross-platform compatible with PostgreSQL.
this side-steps the issue by removing PostgreSQL as test vector altogether, at least until the root issue gets fixed.